### PR TITLE
fix: resolve type errors in saldos and lecturas pages

### DIFF
--- a/app/lecturas/page.tsx
+++ b/app/lecturas/page.tsx
@@ -37,11 +37,20 @@ export default function LecturasPage() {
   }, [])
 
   const handleChange = (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
-    const { name, value, type, checked } = e.target
-    setForm(prev => ({
-      ...prev,
-      [name]: type === 'checkbox' ? checked : value
-    }))
+    const target = e.target
+    const { name, value } = target
+    if (target instanceof HTMLInputElement && target.type === 'checkbox') {
+      const { checked } = target
+      setForm(prev => ({
+        ...prev,
+        [name]: checked
+      }))
+    } else {
+      setForm(prev => ({
+        ...prev,
+        [name]: value
+      }))
+    }
   }
 
   const handleSubmit = async (e: React.FormEvent) => {

--- a/lib/saldos.ts
+++ b/lib/saldos.ts
@@ -1,4 +1,4 @@
-import type { Reading, Bimestre, ResultadoBimestre } from '@/lib/types'
+import type { Reading } from '@/lib/types'
 
 export type Bimestre = {
   nombre: string


### PR DESCRIPTION
## Summary
- remove redundant type imports in saldos utility
- guard checkbox handling in lecturas page to satisfy TypeScript

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: requires interactive ESLint setup)
- `npx tsc --noEmit && echo tsc-success`


------
https://chatgpt.com/codex/tasks/task_e_6894edc5819c832f8ee23b6a9d2e0755