### PR TITLE
style: align lecturas and bimestres pages with home page

### DIFF
--- a/app/bimestres/page.tsx
+++ b/app/bimestres/page.tsx
@@ -257,74 +257,76 @@ export default function BimestresPage() {
 
 
   return (
-    <main className="max-w-4xl mx-auto p-4">
-      <h1 className="text-2xl font-bold mb-4">Lecturas por bimestre</h1>
+    <main className="min-h-screen bg-gradient-to-b from-sky-100 to-sky-200 p-6 flex flex-col items-center">
+      <div className="w-full max-w-4xl bg-white rounded-xl shadow-md p-6">
+        <h1 className="text-2xl font-bold mb-4 text-sky-900">Lecturas por bimestre</h1>
 
-      {bimestres.length > 0 && (
-        <div className="mb-4">
-          <label className="font-medium">Seleccionar bimestre:</label>
-          <select
-            value={bimestreActivo?.nombre}
-            onChange={(e) =>
-              setBimestreActivo(bimestres.find(b => b.nombre === e.target.value) ?? null)
-            }
-            className="ml-2 border px-2 py-1 rounded"
-          >
-            {bimestres.map((b, i) => (
-              <option key={i} value={b.nombre}>{b.nombre}</option>
-            ))}
-          </select>
-        </div>
-      )}
+        {bimestres.length > 0 && (
+          <div className="mb-4">
+            <label className="font-medium text-sky-900">Seleccionar bimestre:</label>
+            <select
+              value={bimestreActivo?.nombre}
+              onChange={(e) =>
+                setBimestreActivo(bimestres.find(b => b.nombre === e.target.value) ?? null)
+              }
+              className="ml-2 border px-2 py-1 rounded"
+            >
+              {bimestres.map((b, i) => (
+                <option key={i} value={b.nombre}>{b.nombre}</option>
+              ))}
+            </select>
+          </div>
+        )}
 
-      {/* Cuadro de resumen */}
-      {calcularResumen()}
+        {/* Cuadro de resumen */}
+        {calcularResumen()}
 
-      {/* Gráfica de consumo neto */}
-      {lecturasFiltradas.length >= 2 && (
-        <div className="mt-6 mb-8">
-          <h2 className="text-lg font-semibold mb-2">📉 Consumo neto diario</h2>
-          <ResponsiveContainer width="100%" height={300}>
-            <LineChart data={chartData()}>
-              <CartesianGrid strokeDasharray="3 3" />
-              <XAxis dataKey="fecha" />
-              <YAxis />
-              <Tooltip />
-              <Legend />
-              <Line type="monotone" dataKey="consumoNeto" stroke="#004184" name="Consumo neto" />
-              <Line type="monotone" dataKey="proyeccion" stroke="#E8871C" name="Proyección" strokeDasharray="4 4" />
-            </LineChart>
-          </ResponsiveContainer>
-        </div>
-      )}
+        {/* Gráfica de consumo neto */}
+        {lecturasFiltradas.length >= 2 && (
+          <div className="mt-6 mb-8">
+            <h2 className="text-lg font-semibold mb-2 text-sky-900">📉 Consumo neto diario</h2>
+            <ResponsiveContainer width="100%" height={300}>
+              <LineChart data={chartData()}>
+                <CartesianGrid strokeDasharray="3 3" />
+                <XAxis dataKey="fecha" />
+                <YAxis />
+                <Tooltip />
+                <Legend />
+                <Line type="monotone" dataKey="consumoNeto" stroke="#004184" name="Consumo neto" />
+                <Line type="monotone" dataKey="proyeccion" stroke="#E8871C" name="Proyección" strokeDasharray="4 4" />
+              </LineChart>
+            </ResponsiveContainer>
+          </div>
+        )}
 
-      {/* Tabla de lecturas */}
-      <h2 className="text-xl font-semibold mb-2">
-        Lecturas del {bimestreActivo?.inicio} al {bimestreActivo?.fin}
-      </h2>
+        {/* Tabla de lecturas */}
+        <h2 className="text-xl font-semibold mb-2 text-sky-900">
+          Lecturas del {bimestreActivo?.inicio} al {bimestreActivo?.fin}
+        </h2>
 
-      <table className="w-full text-sm border-collapse">
-        <thead>
-          <tr className="bg-gray-100">
-            <th className="border px-2 py-1">Fecha</th>
-            <th className="border px-2 py-1">Tomada</th>
-            <th className="border px-2 py-1">Inyectada</th>
-            <th className="border px-2 py-1">Corte</th>
-            <th className="border px-2 py-1">Observación</th>
-          </tr>
-        </thead>
-        <tbody>
-          {lecturasFiltradas.map((r) => (
-            <tr key={r.id}>
-              <td className="border px-2 py-1">{r.fecha}</td>
-              <td className="border px-2 py-1">{r.tomada}</td>
-              <td className="border px-2 py-1">{r.inyectada}</td>
-              <td className="border px-2 py-1">{r.corte ? '✅' : '—'}</td>
-              <td className="border px-2 py-1">{r.observacion ?? '—'}</td>
+        <table className="w-full text-sm border-collapse">
+          <thead>
+            <tr className="bg-sky-100">
+              <th className="border px-2 py-1">Fecha</th>
+              <th className="border px-2 py-1">Tomada</th>
+              <th className="border px-2 py-1">Inyectada</th>
+              <th className="border px-2 py-1">Corte</th>
+              <th className="border px-2 py-1">Observación</th>
             </tr>
-          ))}
-        </tbody>
-      </table>
+          </thead>
+          <tbody>
+            {lecturasFiltradas.map((r) => (
+              <tr key={r.id}>
+                <td className="border px-2 py-1">{r.fecha}</td>
+                <td className="border px-2 py-1">{r.tomada}</td>
+                <td className="border px-2 py-1">{r.inyectada}</td>
+                <td className="border px-2 py-1">{r.corte ? '✅' : '—'}</td>
+                <td className="border px-2 py-1">{r.observacion ?? '—'}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
     </main>
   )
 }

--- a/app/lecturas/page.tsx
+++ b/app/lecturas/page.tsx
@@ -79,57 +79,88 @@ export default function LecturasPage() {
   }
 
   return (
-    <main className="max-w-2xl mx-auto p-4">
-      <h1 className="text-2xl font-bold mb-4">Registrar lectura</h1>
-      <form onSubmit={handleSubmit} className="space-y-4 border p-4 rounded shadow">
-        <div>
-          <label className="block font-medium">Fecha</label>
-          <input type="date" name="fecha" value={form.fecha} onChange={handleChange} required className="w-full border px-2 py-1 rounded" />
-        </div>
-        <div>
-          <label className="block font-medium">kWh tomados</label>
-          <input type="number" name="tomada" value={form.tomada} onChange={handleChange} required className="w-full border px-2 py-1 rounded" />
-        </div>
-        <div>
-          <label className="block font-medium">kWh inyectados</label>
-          <input type="number" name="inyectada" value={form.inyectada} onChange={handleChange} required className="w-full border px-2 py-1 rounded" />
-        </div>
-        <div className="flex items-center gap-2">
-          <input type="checkbox" name="corte" checked={form.corte} onChange={handleChange} />
-          <label className="font-medium">¿Es corte?</label>
-        </div>
-        <div>
-          <label className="block font-medium">Observaciones</label>
-          <textarea name="observacion" value={form.observacion} onChange={handleChange} className="w-full border px-2 py-1 rounded" />
-        </div>
-        <button type="submit" className="bg-blue-600 text-white px-4 py-2 rounded hover:bg-blue-700">
-          Guardar lectura
-        </button>
-      </form>
+    <main className="min-h-screen bg-gradient-to-b from-sky-100 to-sky-200 p-6 flex flex-col items-center">
+      <div className="w-full max-w-2xl bg-white rounded-xl shadow-md p-6">
+        <h1 className="text-2xl font-bold mb-4 text-sky-900">Registrar lectura</h1>
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <div>
+            <label className="block font-medium text-sky-700">Fecha</label>
+            <input
+              type="date"
+              name="fecha"
+              value={form.fecha}
+              onChange={handleChange}
+              required
+              className="w-full border px-2 py-1 rounded"
+            />
+          </div>
+          <div>
+            <label className="block font-medium text-sky-700">kWh tomados</label>
+            <input
+              type="number"
+              name="tomada"
+              value={form.tomada}
+              onChange={handleChange}
+              required
+              className="w-full border px-2 py-1 rounded"
+            />
+          </div>
+          <div>
+            <label className="block font-medium text-sky-700">kWh inyectados</label>
+            <input
+              type="number"
+              name="inyectada"
+              value={form.inyectada}
+              onChange={handleChange}
+              required
+              className="w-full border px-2 py-1 rounded"
+            />
+          </div>
+          <div className="flex items-center gap-2">
+            <input type="checkbox" name="corte" checked={form.corte} onChange={handleChange} />
+            <label className="font-medium text-sky-700">¿Es corte?</label>
+          </div>
+          <div>
+            <label className="block font-medium text-sky-700">Observaciones</label>
+            <textarea
+              name="observacion"
+              value={form.observacion}
+              onChange={handleChange}
+              className="w-full border px-2 py-1 rounded"
+            />
+          </div>
+          <button
+            type="submit"
+            className="bg-sky-700 text-white px-4 py-2 rounded hover:bg-sky-800 transition-colors"
+          >
+            Guardar lectura
+          </button>
+        </form>
 
-      <h2 className="text-xl font-semibold mt-8 mb-2">Lecturas registradas</h2>
-      <table className="w-full text-sm border-collapse">
-        <thead>
-          <tr className="bg-gray-100">
-            <th className="border px-2 py-1">Fecha</th>
-            <th className="border px-2 py-1">Tomada</th>
-            <th className="border px-2 py-1">Inyectada</th>
-            <th className="border px-2 py-1">Corte</th>
-            <th className="border px-2 py-1">Observación</th>
-          </tr>
-        </thead>
-        <tbody>
-          {lecturas.map((r) => (
-            <tr key={r.id}>
-              <td className="border px-2 py-1">{r.fecha}</td>
-              <td className="border px-2 py-1">{r.tomada}</td>
-              <td className="border px-2 py-1">{r.inyectada}</td>
-              <td className="border px-2 py-1">{r.corte ? '✅' : '—'}</td>
-              <td className="border px-2 py-1">{r.observacion ?? '—'}</td>
+        <h2 className="text-xl font-semibold mt-8 mb-2 text-sky-900">Lecturas registradas</h2>
+        <table className="w-full text-sm border-collapse">
+          <thead>
+            <tr className="bg-sky-100">
+              <th className="border px-2 py-1">Fecha</th>
+              <th className="border px-2 py-1">Tomada</th>
+              <th className="border px-2 py-1">Inyectada</th>
+              <th className="border px-2 py-1">Corte</th>
+              <th className="border px-2 py-1">Observación</th>
             </tr>
-          ))}
-        </tbody>
-      </table>
+          </thead>
+          <tbody>
+            {lecturas.map((r) => (
+              <tr key={r.id}>
+                <td className="border px-2 py-1">{r.fecha}</td>
+                <td className="border px-2 py-1">{r.tomada}</td>
+                <td className="border px-2 py-1">{r.inyectada}</td>
+                <td className="border px-2 py-1">{r.corte ? '✅' : '—'}</td>
+                <td className="border px-2 py-1">{r.observacion ?? '—'}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
     </main>
   )
 }


### PR DESCRIPTION
## Summary
- Match Lecturas page styling with home page via gradient background and card layout
- Apply home page styling to Bimestres view, including gradient background and sky-colored headers

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: requires ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68950f316710832fac150544ab4c7939