### PR TITLE
Add home links to Lecturas and Bimestres pages

### DIFF
--- a/app/bimestres/page.tsx
+++ b/app/bimestres/page.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { useEffect, useState } from 'react'
+import Link from 'next/link'
 import { supabase } from '@/lib/supabase'
 import { Reading } from '@/lib/types'
 import {
@@ -259,6 +260,9 @@ export default function BimestresPage() {
   return (
     <main className="min-h-screen bg-gradient-to-b from-sky-100 to-sky-200 p-6 flex flex-col items-center">
       <div className="w-full max-w-4xl bg-white rounded-xl shadow-md p-6">
+        <Link href="/" className="text-sky-700 hover:underline">
+          &larr; Inicio
+        </Link>
         <h1 className="text-2xl font-bold mb-4 text-sky-900">Lecturas por bimestre</h1>
 
         {bimestres.length > 0 && (

--- a/app/lecturas/page.tsx
+++ b/app/lecturas/page.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { useEffect, useState } from 'react'
+import Link from 'next/link'
 import { supabase } from '@/lib/supabase'
 
 type Reading = {
@@ -81,6 +82,9 @@ export default function LecturasPage() {
   return (
     <main className="min-h-screen bg-gradient-to-b from-sky-100 to-sky-200 p-6 flex flex-col items-center">
       <div className="w-full max-w-2xl bg-white rounded-xl shadow-md p-6">
+        <Link href="/" className="text-sky-700 hover:underline">
+          &larr; Inicio
+        </Link>
         <h1 className="text-2xl font-bold mb-4 text-sky-900">Registrar lectura</h1>
         <form onSubmit={handleSubmit} className="space-y-4">
           <div>


### PR DESCRIPTION
## Summary
- Add "Inicio" link to navigate back home from Lecturas
- Add matching "Inicio" link on Bimestres page

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: ESLint configuration prompt)*

------
https://chatgpt.com/codex/tasks/task_e_689519813dbc832f870bb9a74af5c7de